### PR TITLE
Add Terraform S3/Lambda setup with GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Terraform Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hashicorp/setup-terraform@v2
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: us-east-1
+      - name: Terraform Init
+        run: terraform -chdir=terraform init
+      - name: Terraform Apply
+        run: terraform -chdir=terraform apply -auto-approve
+

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -1,0 +1,24 @@
+name: Terraform Destroy
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  destroy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hashicorp/setup-terraform@v2
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: us-east-1
+      - name: Terraform Init
+        run: terraform -chdir=terraform init
+      - name: Terraform Destroy
+        run: terraform -chdir=terraform destroy -auto-approve
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+*.tfvars.json
+crash.log
+*.zip
+
+# Python
+__pycache__/
+*.pyc
+
+# General
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# openai-with-aws-test4
+# OpenAI with AWS Test 4
+
+This example uses Terraform to create an S3 bucket, Lambda function and API Gateway. GitHub Actions deploys the Terraform configuration using an AWS role.
+
+## Terraform
+- Creates an S3 bucket `ontoscale-create-with-openai-codex`.
+- Packages a Python Lambda that writes a file into the bucket and exposes it via HTTP API Gateway.
+- Remote state is stored in `ontoscale-terraform-backend` S3 bucket.
+
+## GitHub Actions
+- `deploy.yml` runs `terraform apply` on pushes to `main` (i.e. after PR merge).
+- `destroy.yml` can be triggered manually to teardown the resources.
+- Both workflows use `AWS_ROLE` secret for OIDC access.

--- a/lambda/lambda_function.py
+++ b/lambda/lambda_function.py
@@ -1,0 +1,14 @@
+import boto3
+import os
+
+def lambda_handler(event, context):
+    s3 = boto3.client('s3')
+    bucket = os.environ['BUCKET_NAME']
+    key = 'lambda_output.txt'
+    content = 'file created by lambda'
+    s3.put_object(Bucket=bucket, Key=key, Body=content)
+    return {
+        'statusCode': 200,
+        'body': f'File {key} created in {bucket}'
+    }
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,128 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    bucket = "ontoscale-terraform-backend"
+    key    = "state/terraform.tfstate"
+    region = "us-east-1"
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket        = "ontoscale-create-with-openai-codex"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_public_access_block" "block" {
+  bucket = aws_s3_bucket.bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Lambda packaging
+data "archive_file" "lambda_zip" {
+  type        = "zip"
+  source_dir  = "${path.module}/../lambda"
+  output_path = "${path.module}/lambda.zip"
+}
+
+resource "aws_iam_role" "lambda_role" {
+  name = "ontoscale_lambda_role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "lambda.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "lambda_policy" {
+  name = "ontoscale_lambda_policy"
+  role = aws_iam_role.lambda_role.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action   = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+        Effect   = "Allow",
+        Resource = "arn:aws:logs:*:*:*"
+      },
+      {
+        Action   = ["s3:PutObject"],
+        Effect   = "Allow",
+        Resource = ["arn:aws:s3:::ontoscale-create-with-openai-codex/*"]
+      }
+    ]
+  })
+}
+
+resource "aws_lambda_function" "lambda" {
+  function_name    = "ontoscale_lambda"
+  role             = aws_iam_role.lambda_role.arn
+  handler          = "lambda_function.lambda_handler"
+  runtime          = "python3.9"
+  filename         = data.archive_file.lambda_zip.output_path
+  source_code_hash = data.archive_file.lambda_zip.output_base64sha256
+  environment {
+    variables = {
+      BUCKET_NAME = aws_s3_bucket.bucket.bucket
+    }
+  }
+}
+
+resource "aws_apigatewayv2_api" "api" {
+  name          = "ontoscale_api"
+  protocol_type = "HTTP"
+}
+
+resource "aws_apigatewayv2_integration" "lambda_integration" {
+  api_id                 = aws_apigatewayv2_api.api.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.lambda.invoke_arn
+  payload_format_version = "2.0"
+}
+
+resource "aws_apigatewayv2_route" "default" {
+  api_id    = aws_apigatewayv2_api.api.id
+  route_key = "$default"
+  target    = "integrations/${aws_apigatewayv2_integration.lambda_integration.id}"
+}
+
+resource "aws_apigatewayv2_stage" "default" {
+  api_id      = aws_apigatewayv2_api.api.id
+  name        = "$default"
+  auto_deploy = true
+}
+
+resource "aws_lambda_permission" "api_gateway" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.lambda.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.api.execution_arn}/*/*"
+}
+
+output "api_endpoint" {
+  value = aws_apigatewayv2_stage.default.invoke_url
+}
+
+variable "aws_region" {
+  type    = string
+  default = "us-east-1"
+}


### PR DESCRIPTION
## Summary
- infrastructure-as-code using Terraform for S3 bucket, Lambda and API Gateway
- GitHub Actions workflows for deploy on merge to `main` and for manual destroy
- lambda writes a file to the created bucket
- store terraform state in `ontoscale-terraform-backend`

## Testing
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_687680b6adc48331a95d32dd15336e69